### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^7.0|^8.0",
         "laravel/helpers": "^1.3",
-        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5|^10.5|^11.5",


### PR DESCRIPTION
Adds `^13.0` to illuminate/* package constraints to support Laravel 13.