### PR TITLE
Register model observer without booting the model (Laravel 13)

### DIFF
--- a/src/Observers/ModelObserver.php
+++ b/src/Observers/ModelObserver.php
@@ -16,8 +16,24 @@ class ModelObserver
 
     public static function observe($class_name)
     {
-        $class_name::observe(
-            ModelObserver::class
-        );
+        /**
+         * Register the observer through the model's static event methods
+         * instead of Model::observe(). As of Laravel 13 Model::observe()
+         * instantiates the model (new static), which throws a LogicException
+         * when called while the model is still booting — and this method runs
+         * from the Observer trait's bootObserver() during boot. The static
+         * event registrars attach a listener without booting the model.
+         */
+        $events = [
+            'retrieved', 'creating', 'created', 'updating', 'updated',
+            'saving', 'saved', 'deleting', 'deleted', 'restoring', 'restored',
+            'trashed', 'forceDeleting', 'forceDeleted', 'replicating',
+        ];
+
+        foreach ($events as $event) {
+            if (method_exists(static::class, $event)) {
+                $class_name::{$event}(static::class . '@' . $event);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why

On Laravel 13 every model using the `Observer` trait throws on first boot:

> The [Illuminate\\Database\\Eloquent\\Model::bootIfNotBooted] method may not be called on model [...] while it is being booted.

`ModelObserver::observe()` calls `Model::observe()`, which does `new static`. The `Observer` trait invokes this from `bootObserver()` **during** model boot, and Laravel 13 added a guard that throws when a model is instantiated while still booting.

## Fix

Register the observer through the model's static event registrars (`$model::saving(...)` etc.), which attach a listener **without** instantiating/booting the model. Only the events `ModelObserver` actually implements are wired up, so behaviour is unchanged (today: `saving`).

Affects every model using `Marshmallow\\HelperFunctions\\Traits\\Observer` — required for Laravel 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)